### PR TITLE
Implement basic trading bot modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
-Creating cryptocurrency trading bot 
+# Trading Bot
+
+This repository contains an example of a modular cryptocurrency trading bot written in Python 3.11. It supports asynchronous data feeds via CCXT, basic indicator calculations, simple strategies, risk management, order execution, Telegram notifications and a CLI interface.
+
+The code is organized in the `bot` package with the following modules:
+
+- `settings.py` – load configuration and API keys from YAML/JSON and environment variables.
+- `datafeed.py` – asynchronous market data using CCXT.
+- `indicators.py` – indicator helpers based on pandas-ta.
+- `strategy.py` – strategy base class and an EMA+RSI example strategy.
+- `risk.py` – position sizing based on fixed risk per trade.
+- `execution.py` – order execution layer using CCXT.
+- `notifier.py` – Telegram notification helper.
+- `backtest.py` – very lightweight backtesting skeleton.
+- `main.py` – CLI with commands `init-project`, `backtest`, `run-live`, `report`.
+
+Install dependencies and run `python -m bot.main --help` for usage information.

--- a/bot/backtest.py
+++ b/bot/backtest.py
@@ -1,0 +1,22 @@
+import logging
+from typing import Callable
+
+import pandas as pd
+
+
+logger = logging.getLogger(__name__)
+
+
+class Backtester:
+    def __init__(self, data: pd.DataFrame) -> None:
+        self.data = data
+
+    def run(self, strategy_factory: Callable[[str], "Strategy"], symbol: str) -> None:
+        strategy = strategy_factory(symbol)
+        for i in range(50, len(self.data)):
+            df_slice = self.data.iloc[: i + 1]
+            for signal in strategy.generate(df_slice):
+                logger.info("Backtest signal: %s", signal)
+
+
+__all__ = ["Backtester"]

--- a/bot/datafeed.py
+++ b/bot/datafeed.py
@@ -1,0 +1,33 @@
+import asyncio
+import logging
+from abc import ABC, abstractmethod
+from typing import AsyncIterator
+
+import ccxt.async_support as ccxt
+
+
+logger = logging.getLogger(__name__)
+
+
+class DataFeed(ABC):
+    @abstractmethod
+    async def subscribe(self, symbol: str) -> AsyncIterator[dict]:
+        pass
+
+
+class CCXTDataFeed(DataFeed):
+    def __init__(self, exchange: str) -> None:
+        self.exchange = getattr(ccxt, exchange)()
+
+    async def subscribe(self, symbol: str) -> AsyncIterator[dict]:
+        while True:
+            try:
+                ticker = await self.exchange.fetch_ticker(symbol)
+                yield ticker
+                await asyncio.sleep(1)
+            except Exception as exc:  # pragma: no cover - network
+                logger.error("Data feed error: %s", exc)
+                await asyncio.sleep(5)
+
+
+__all__ = ["DataFeed", "CCXTDataFeed"]

--- a/bot/execution.py
+++ b/bot/execution.py
@@ -1,0 +1,35 @@
+import logging
+from abc import ABC, abstractmethod
+
+import ccxt.async_support as ccxt
+
+
+logger = logging.getLogger(__name__)
+
+
+class Execution(ABC):
+    @abstractmethod
+    async def create_order(self, symbol: str, side: str, amount: float, price: float | None = None) -> dict:
+        pass
+
+
+class CCXTExecution(Execution):
+    def __init__(self, exchange: str, api_key: str, api_secret: str) -> None:
+        exchange_class = getattr(ccxt, exchange)
+        self.client = exchange_class({
+            "apiKey": api_key,
+            "secret": api_secret,
+            "enableRateLimit": True,
+        })
+
+    async def create_order(self, symbol: str, side: str, amount: float, price: float | None = None) -> dict:
+        try:
+            order = await self.client.create_order(symbol, "market", side.lower(), amount, price)
+            logger.info("Order created: %s", order)
+            return order
+        except Exception as exc:  # pragma: no cover - network
+            logger.error("Order failed: %s", exc)
+            raise
+
+
+__all__ = ["Execution", "CCXTExecution"]

--- a/bot/indicators.py
+++ b/bot/indicators.py
@@ -1,0 +1,19 @@
+import pandas as pd
+import pandas_ta as ta
+
+
+def ema(series: pd.Series, length: int = 20) -> pd.Series:
+    return ta.ema(series, length=length)
+
+
+def rsi(series: pd.Series, length: int = 14) -> pd.Series:
+    return ta.rsi(series, length=length)
+
+
+def supertrend(df: pd.DataFrame, length: int = 10, multiplier: float = 3.0) -> pd.DataFrame:
+    st = ta.supertrend(high=df["high"], low=df["low"], close=df["close"],
+                       length=length, multiplier=multiplier)
+    return st
+
+
+__all__ = ["ema", "rsi", "supertrend"]

--- a/bot/main.py
+++ b/bot/main.py
@@ -1,0 +1,69 @@
+import asyncio
+import logging
+from pathlib import Path
+
+import pandas as pd
+import typer
+
+from .backtest import Backtester
+from .datafeed import CCXTDataFeed
+from .execution import CCXTExecution
+from .notifier import TelegramNotifier
+from .risk import PositionSizing
+from .settings import load_settings
+from .strategy import EMARsiStrategy, Signal
+
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+app = typer.Typer()
+
+
+@app.command()
+def init_project(config_path: Path = Path("config.yml")) -> None:
+    if not config_path.exists():
+        config_path.write_text("exchange:\n  name: binance\ntrading_pairs:\n  - BTC/USDT\n")
+        typer.echo(f"Created default config at {config_path}")
+    else:
+        typer.echo("Config already exists")
+
+
+@app.command()
+def backtest(config: Path = Path("config.yml")) -> None:
+    settings = load_settings(config)
+    df = pd.DataFrame()  # placeholder: load your historical data here
+    backtester = Backtester(df)
+    backtester.run(lambda s: EMARsiStrategy(s), settings.trading_pairs[0])
+
+
+@app.command()
+def run_live(config: Path = Path("config.yml")) -> None:
+    settings = load_settings(config)
+    feed = CCXTDataFeed(settings.exchange.name)
+    exec_client = CCXTExecution(settings.exchange.name, settings.exchange.api_key, settings.exchange.api_secret)
+    notifier = None
+    if settings.telegram_token and settings.telegram_chat_id:
+        notifier = TelegramNotifier(settings.telegram_token, settings.telegram_chat_id)
+
+    position = PositionSizing(balance=100.0, risk_per_trade=settings.risk_per_trade, leverage=settings.leverage)
+
+    async def run() -> None:
+        async for data in feed.subscribe(settings.trading_pairs[0]):
+            df = pd.DataFrame([data])
+            strategy = EMARsiStrategy(settings.trading_pairs[0])
+            for signal in strategy.generate(df):
+                size = position.calculate_size(stop_distance=10)
+                await exec_client.create_order(signal.symbol, signal.side, size)
+                if notifier:
+                    await notifier.send(f"{signal.side} {signal.symbol} at {signal.price}")
+    asyncio.run(run())
+
+
+@app.command()
+def report() -> None:
+    typer.echo("Reporting is not implemented yet")
+
+
+if __name__ == "__main__":
+    app()

--- a/bot/notifier.py
+++ b/bot/notifier.py
@@ -1,0 +1,25 @@
+import asyncio
+import logging
+
+import aiohttp
+
+logger = logging.getLogger(__name__)
+
+
+class TelegramNotifier:
+    def __init__(self, token: str, chat_id: str) -> None:
+        self.base_url = f"https://api.telegram.org/bot{token}/sendMessage"
+        self.chat_id = chat_id
+
+    async def send(self, message: str) -> None:
+        async with aiohttp.ClientSession() as session:
+            payload = {"chat_id": self.chat_id, "text": message}
+            try:
+                async with session.post(self.base_url, data=payload) as resp:
+                    if resp.status != 200:
+                        logger.error("Telegram notification failed: %s", await resp.text())
+            except Exception as exc:  # pragma: no cover - network
+                logger.error("Telegram error: %s", exc)
+
+
+__all__ = ["TelegramNotifier"]

--- a/bot/risk.py
+++ b/bot/risk.py
@@ -1,0 +1,23 @@
+import logging
+from dataclasses import dataclass
+
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class PositionSizing:
+    balance: float
+    risk_per_trade: float
+    leverage: int
+
+    def calculate_size(self, stop_distance: float) -> float:
+        if stop_distance <= 0:
+            raise ValueError("Stop distance must be positive")
+        risk_amount = self.balance * self.risk_per_trade
+        size = (risk_amount * self.leverage) / stop_distance
+        logger.debug("Calculated position size: %s", size)
+        return size
+
+
+__all__ = ["PositionSizing"]

--- a/bot/settings.py
+++ b/bot/settings.py
@@ -1,0 +1,58 @@
+from dataclasses import dataclass
+from pathlib import Path
+import json
+import yaml
+import os
+from typing import Any, Dict
+from dotenv import load_dotenv
+
+
+@dataclass
+class ExchangeConfig:
+    name: str
+    api_key: str
+    api_secret: str
+    passphrase: str | None = None
+
+
+@dataclass
+class Settings:
+    exchange: ExchangeConfig
+    trading_pairs: list[str]
+    risk_per_trade: float = 0.02
+    leverage: int = 1
+    telegram_token: str | None = None
+    telegram_chat_id: str | None = None
+
+
+CONFIG_PATH = Path("config.yml")
+
+
+def load_settings(path: Path = CONFIG_PATH) -> Settings:
+    load_dotenv()
+    data: Dict[str, Any]
+    if path.suffix in {".yml", ".yaml"}:
+        data = yaml.safe_load(path.read_text())
+    else:
+        data = json.loads(path.read_text())
+
+    exchange = data.get("exchange", {})
+    exchange_config = ExchangeConfig(
+        name=exchange.get("name", "binance"),
+        api_key=os.getenv("API_KEY", exchange.get("api_key", "")),
+        api_secret=os.getenv("API_SECRET", exchange.get("api_secret", "")),
+        passphrase=os.getenv("PASSPHRASE", exchange.get("passphrase")),
+    )
+
+    settings = Settings(
+        exchange=exchange_config,
+        trading_pairs=data.get("trading_pairs", ["BTC/USDT"]),
+        risk_per_trade=float(data.get("risk_per_trade", 0.02)),
+        leverage=int(data.get("leverage", 1)),
+        telegram_token=os.getenv("TG_TOKEN", data.get("telegram_token")),
+        telegram_chat_id=os.getenv("TG_CHAT_ID", data.get("telegram_chat_id")),
+    )
+    return settings
+
+
+__all__ = ["Settings", "load_settings"]

--- a/bot/strategy.py
+++ b/bot/strategy.py
@@ -1,0 +1,50 @@
+import logging
+from dataclasses import dataclass
+from typing import Iterable
+
+import pandas as pd
+
+from .indicators import ema, rsi
+
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class Signal:
+    side: str  # "BUY" or "SELL"
+    price: float
+    symbol: str
+
+
+class Strategy:
+    def __init__(self, symbol: str) -> None:
+        self.symbol = symbol
+
+    def generate(self, df: pd.DataFrame) -> Iterable[Signal]:
+        raise NotImplementedError
+
+
+class EMARsiStrategy(Strategy):
+    def __init__(self, symbol: str, ema_fast: int = 12, ema_slow: int = 26, rsi_len: int = 14) -> None:
+        super().__init__(symbol)
+        self.ema_fast = ema_fast
+        self.ema_slow = ema_slow
+        self.rsi_len = rsi_len
+
+    def generate(self, df: pd.DataFrame) -> Iterable[Signal]:
+        df = df.copy()
+        df["ema_fast"] = ema(df["close"], self.ema_fast)
+        df["ema_slow"] = ema(df["close"], self.ema_slow)
+        df["rsi"] = rsi(df["close"], self.rsi_len)
+
+        latest = df.iloc[-1]
+        if latest["ema_fast"] > latest["ema_slow"] and latest["rsi"] < 70:
+            logger.debug("Buy signal generated")
+            yield Signal(side="BUY", price=float(latest["close"]), symbol=self.symbol)
+        elif latest["ema_fast"] < latest["ema_slow"] and latest["rsi"] > 30:
+            logger.debug("Sell signal generated")
+            yield Signal(side="SELL", price=float(latest["close"]), symbol=self.symbol)
+
+
+__all__ = ["Signal", "Strategy", "EMARsiStrategy"]


### PR DESCRIPTION
## Summary
- add `bot` package with modular Python trading bot code
- implement settings loader, data feed, indicator helpers and strategy logic
- add execution layer, Telegram notifier, and simple backtester
- provide CLI entry point in `main.py`
- update `README` with module overview

## Testing
- `python -m py_compile bot/*.py`
- `pip install pandas pandas-ta aiohttp ccxt typer python-dotenv pyyaml`
- `python -m bot.main --help` *(fails: ImportError from pandas_ta)*

------
https://chatgpt.com/codex/tasks/task_e_684ddd0855fc83288a2cb07be459290f